### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -156,6 +156,8 @@ jobs:
 
     python-code-quality:
         name: Python code quality checks
+        permissions:
+          contents: read
         runs-on: ubuntu-24.04
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/LFGlala/monad/security/code-scanning/8](https://github.com/LFGlala/monad/security/code-scanning/8)

To fix the problem, you should add an explicit `permissions:` block to the `python-code-quality` job. The least privilege needed for this job is `contents: read`, as it only checks out source code and performs code analysis. This can be accomplished by inserting a `permissions:` block with `contents: read` just after the job name (i.e., after `name: Python code quality checks`, before or after `runs-on:` is acceptable, but for clarity it is often placed after `name`). No other changes, imports, or dependency updates are required, and no existing functional behavior is affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
